### PR TITLE
Corrected text on help page 

### DIFF
--- a/help.html
+++ b/help.html
@@ -41,7 +41,7 @@
       <p>Bugger is a fresh, code-based take on an 80's arcade classic. In it, you play as a bug - a broken piece of code - and
         your goal is to remain undetected and scurry your way into production. You will be dodging various strings of linter
         errors (represented as binary code) to successfully burrow away and wait until launch day.</p>
-      <p>Use the W, A, S, and D keys to navigate this treacherous landscape and avoid the linter to keep it from detecting your
+      <p>Use the arrow keys to navigate this treacherous landscape and avoid the linter to keep it from detecting your
         presence! If you bump into a linter error, it will have caught you and the software engineers will remove you from
         existence. Yikes! </p>
       <p>Try to get a high score! If you make it into the top ten, you will have the opportunity to be memorialized for posterity


### PR DESCRIPTION
The help page now says that the arrow keys are used for maneuvering, instead of saying the W, A, S, and D keys are used.